### PR TITLE
highlight-escape-sequences: Apply changes to buffers without revert.

### DIFF
--- a/highlight-escape-sequences.el
+++ b/highlight-escape-sequences.el
@@ -7,6 +7,7 @@
 ;; URL:      https://github.com/dgutov/highlight-escape-sequences
 ;; Keywords: convenience
 ;; Version:  0.4
+;; Package-Requires: ((emacs "25.1"))
 
 ;; This file is part of GNU Emacs.
 
@@ -205,47 +206,45 @@ Currently handles:
                (hes-mode 1))
            (set-default symbol value))))
 
-;;;###autoload
 (defun turn-on-hes-mode()
   "Turn on highlighting of escape sequences."
   (interactive)
   (dolist (mode hes-mode-alist)
     (if (atom mode)
         (font-lock-add-keywords
-         mode
-         (hes-make-simple-escape-sequence-keywords hes-common-escape-sequence-re)
-         'append)
+         nil
+         (hes-make-simple-escape-sequence-keywords hes-common-escape-sequence-re))
       (when (stringp (cdr mode))
         (font-lock-add-keywords
-         (car mode)
-         (hes-make-simple-escape-sequence-keywords (cdr mode))
-         'append))
+         nil
+         (hes-make-simple-escape-sequence-keywords (cdr mode))))
       (when (listp (cdr mode))
-        (font-lock-add-keywords (car mode) (cdr mode) 'append)))))
+        (font-lock-add-keywords nil (cdr mode))))))
 
-;;;###autoload
 (defun turn-off-hes-mode()
   "Turn off highlighting of escape sequences"
   (interactive)
   (dolist (mode hes-mode-alist)
     (if (atom mode)
         (font-lock-remove-keywords
-         mode
+         nil
          (hes-make-simple-escape-sequence-keywords hes-common-escape-sequence-re))
       (when (stringp (cdr mode))
         (font-lock-remove-keywords
-         (car mode)
+         nil
          (hes-make-simple-escape-sequence-keywords (cdr mode))))
       (when (listp (cdr mode))
-        (font-lock-remove-keywords (car mode) (cdr mode))))))
+        (font-lock-remove-keywords nil (cdr mode))))))
 
 ;;;###autoload
 (define-minor-mode hes-mode
   "Toggle highlighting of escape sequences."
-  :lighter "" :global t
+  :init-value nil
+  :lighter " hes"
   (if hes-mode
       (turn-on-hes-mode)
-    (turn-off-hes-mode)))
+    (turn-off-hes-mode))
+  (font-lock-flush))
 
 (provide 'highlight-escape-sequences)
 


### PR DESCRIPTION
* highlight-escape-sequences.el (turn-on-hes-mode, turn-off-hes-mode):
  Set font-lock-add-keywords mode to nil.  Remove autoload.
* highlight-escape-sequences.el (hes-mode): Add font-lock-flush.  Set
  init-value to nil.  Remove global keyword.  Set lighter to " hes".

Hello,

This patch fixes following from issue #6:

-￼ (turn-on-hes-mode) doesn't apply to the current buffer. To turn on hes-mode you need to M-x revert-buffer.
￼- Same with (turn-off-hes-mode).
￼- (turn-on-hes-mode) and (turn-off-hes-mode) works only globally, not locally for buffer.

![](https://raw.githubusercontent.com/wigust/misc/master/emacs-highlight-escape-sequences-without-revert.gif)

Thanks,
Oleg.